### PR TITLE
Add DOI to document

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,10 +1,8 @@
-
-
-
-
 :tocdepth: 1
 
 .. Please do not modify tocdepth; will be fixed when a new Sphinx theme is shipped.
+
+**DOI:** `10.5281/zenodo.1492936 <https://doi.org/10.5281/zenodo.1492936>`_
 
 .. note::
 


### PR DESCRIPTION
In the prototype system it turns out the DOI needs to be manually copied into the document itself. This commit does that.